### PR TITLE
Update to support 2026 events & CCN registration

### DIFF
--- a/src/components/Menu/routes.ts
+++ b/src/components/Menu/routes.ts
@@ -4,17 +4,27 @@ export const shop = [
 ]
 
 export const seasons = [
+  { label: '2026', route: '/event/2026/' },
+  { label: '2025', route: '/event/2025/' },
   { label: '2024', route: '/event/2024/' },
   { label: '2023', route: '/event/2023/' },
   { label: '2022', route: '/event/2022/' },
-  { label: 'Archive', route: '/event/' }
+  { label: 'Archive', route: '/event/' },
 ]
 
 export const registration = [
-  { label: 'Membership', description: 'Become a member', route: '/registration/membership/' },
+  {
+    label: 'Membership',
+    description: 'Become a member',
+    route: '/registration/membership/',
+  },
   { label: 'Rides', description: 'Scheduled rides', route: '/registration/' },
   { label: 'Permanents', route: '/registration/permanent/' },
-  { label: 'Trace', description: 'Trace Virtuelle', route: '/registration/trace-virtuelle/' },
+  {
+    label: 'Trace',
+    description: 'Trace Virtuelle',
+    route: '/registration/trace-virtuelle/',
+  },
 ]
 
 export const loneliness = [
@@ -23,8 +33,16 @@ export const loneliness = [
 ]
 
 export const symposium = [
-  { label: '2020', description: '2020 Virtual Symposium', route: '/symposium/2020' },
-  { label: '2021', description: '2021 Virtual Symposium', route: '/symposium/2021' },
+  {
+    label: '2020',
+    description: '2020 Virtual Symposium',
+    route: '/symposium/2020',
+  },
+  {
+    label: '2021',
+    description: '2021 Virtual Symposium',
+    route: '/symposium/2021',
+  },
 ]
 
 export default {
@@ -32,5 +50,5 @@ export default {
   registration,
   seasons,
   loneliness,
-  shop
+  shop,
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -16,7 +16,7 @@ import UpcomingEvents from 'src/components/UpcomingEvents'
 import * as styles from './styles/index.module.scss'
 import { iframe } from 'src/components/styles/iframe.module.scss'
 
-const currentSeason = '2024'
+const currentSeason = '2026'
 
 const pageQuery = graphql`
   query indexPageQuery {

--- a/src/pages/registration/membership.tsx
+++ b/src/pages/registration/membership.tsx
@@ -43,7 +43,7 @@ const MemberRegistration = ({ path }: PageProps) => {
             </small>
           </p>
           <LinkButton
-            href="https://ccnbikes.com/#!/events/randonneurs-ontario-membership-2025"
+            href="https://ccnbikes.com/#!/events/randonneurs-ontario-membership-2026"
             secondary
             small
             block
@@ -64,7 +64,7 @@ const MemberRegistration = ({ path }: PageProps) => {
             </small>
           </p>
           <LinkButton
-            href="https://ccnbikes.com/#!/events/randonneurs-ontario-membership-2025"
+            href="https://ccnbikes.com/#!/events/randonneurs-ontario-membership-2026"
             primary
             small
             block
@@ -85,7 +85,7 @@ const MemberRegistration = ({ path }: PageProps) => {
             </small>
           </p>
           <LinkButton
-            href="https://ccnbikes.com/#!/events/randonneurs-ontario-membership-2025"
+            href="https://ccnbikes.com/#!/events/randonneurs-ontario-membership-2026"
             secondary
             small
             block


### PR DESCRIPTION
Some minor updates to support the 2026 season on the registration site. I'm pretty sure we still need to update the `RO_ENDPOINT` environment variable on Netlify to pull events from the correct date range on `https://www.randonneursontario.ca/brevetcard/schedule.php`.